### PR TITLE
fix: incorrect usage of `ethers.JsonRpcProvider`

### DIFF
--- a/examples/src/base/account.ts
+++ b/examples/src/base/account.ts
@@ -4,7 +4,7 @@ export function account(
     privateKey: string,
     rpc_url: string,
 ) {
-    const provider = new ethers.JsonRpcProvider(rpc_url);
+    const provider = new ethers.providers.JsonRpcProvider(rpc_url);
     const account0 = new ethers.Wallet(privateKey, provider);
     return account0;
 }


### PR DESCRIPTION
corrected an issue where `ethers.JsonRpcProvider` was being used, which doesn't exist and causes a compilation error.
the correct way to create an RPC provider instance is by using `ethers.providers.JsonRpcProvider`.