### PR TITLE
chore: bump version to 1.0.1 and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-# Fibrous Finance SDK (v1.0.0)
+# Fibrous Finance SDK (v1.0.1)
 
 ## Installation
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-# Fibrous Finance SDK (v1.0.0)
+# Fibrous Finance SDK (v1.0.1)
 
 [Full Documentation](https://docs.fibrous.finance/)
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -27,7 +27,7 @@
     "setup:env": "echo 'Please create a .env file with required environment variables. Check README for details.'"
   },
   "dependencies": {
-    "fibrous-router-sdk": "file:../fibrous-router-sdk-1.0.0-beta.1.tgz",
+    "fibrous-router-sdk": "1.0.1",
     "starknet": "^7.6.4",
     "tsx": "^4.20.3"
   }

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -9,8 +9,11 @@ importers:
   .:
     dependencies:
       fibrous-router-sdk:
-        specifier: ^0.5.1
-        version: 0.5.1
+        specifier: 1.0.1
+        version: 1.0.1
+      starknet:
+        specifier: ^7.6.4
+        version: 7.6.4
       tsx:
         specifier: ^4.20.3
         version: 4.20.3
@@ -170,15 +173,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ethersproject/bignumber@5.8.0':
-    resolution: {integrity: sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==}
-
-  '@ethersproject/bytes@5.8.0':
-    resolution: {integrity: sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==}
-
-  '@ethersproject/logger@5.8.0':
-    resolution: {integrity: sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==}
-
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
@@ -203,6 +197,9 @@ packages:
   '@starknet-io/types-js@0.7.10':
     resolution: {integrity: sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==}
 
+  '@starknet-io/types-js@0.8.4':
+    resolution: {integrity: sha512-0RZ3TZHcLsUTQaq1JhDSCM8chnzO4/XNsSCozwDET64JK5bjFDIf2ZUkta+tl5Nlbf4usoU7uZiDI/Q57kt2SQ==}
+
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
@@ -224,9 +221,6 @@ packages:
   ansicolors@0.3.2:
     resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
 
-  bn.js@5.2.2:
-    resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
-
   cardinal@2.1.1:
     resolution: {integrity: sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==}
     hasBin: true
@@ -242,8 +236,8 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  dotenv@16.5.0:
-    resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
   emoji-regex@8.0.0:
@@ -263,18 +257,12 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  ethers@6.14.4:
-    resolution: {integrity: sha512-Jm/dzRs2Z9iBrT6e9TvGxyb5YVKAPLlpna7hjxH7KH/++DSh2T/JVmQUv7iHI5E55hDbp/gEVvstWYXVxXFzsA==}
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
     engines: {node: '>=14.0.0'}
 
-  fetch-cookie@3.0.1:
-    resolution: {integrity: sha512-ZGXe8Y5Z/1FWqQ9q/CrJhkUD73DyBU9VF0hBQmEO/wPHe4A9PKTjplFDLeFX8aOsYypZUcX5Ji/eByn3VCVO3Q==}
-
-  fibrous-router-sdk@0.4.5:
-    resolution: {integrity: sha512-bd0SaFRfc0GnROg00QYyPN3Z3xvQYj9ml/6KmTfmZKkVOHfOYcEco+aWDhv6wafNKter8xuQ7wNH2V7gtkjydA==}
-
-  fibrous-router-sdk@0.5.1:
-    resolution: {integrity: sha512-0Vq09wBwqLqOKKXOCrR2TzFqkOCmRK9flo709TFvlNCQNP0BOsFju14w+eUl95T1H3nNDQkptCFhDaa/3IQUpw==}
+  fibrous-router-sdk@1.0.1:
+    resolution: {integrity: sha512-OGIFvU/NZgGXKuNk3KevXv3fNVi3xB6plBVkUb9GvtVjEXQ50oqYrqWhYt0azwRFOS2cRzE7aXUw6tqGy8Cidg==}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -299,36 +287,14 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  isomorphic-fetch@3.0.0:
-    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
-
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
   lossless-json@4.1.0:
     resolution: {integrity: sha512-DgoRs42jH/yNubp8iinRqvG0xn5awHKXVY+7lGYjBaByoHGZt/Dz5Jkaf5znP2XHbTnAA+bbkhK3lMIaf3+92A==}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
-
-  psl@1.15.0:
-    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
-
-  punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
-
-  querystringify@2.2.0:
-    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   redeyed@2.1.1:
     resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
@@ -337,17 +303,12 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  requires-port@1.0.0:
-    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
-
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  set-cookie-parser@2.7.1:
-    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
-
-  starknet@6.24.1:
-    resolution: {integrity: sha512-g7tiCt73berhcNi41otlN3T3kxZnIvZhMi8WdC21Y6GC6zoQgbI2z1t7JAZF9c4xZiomlanwVnurcpyfEdyMpg==}
+  starknet@7.6.4:
+    resolution: {integrity: sha512-FB20IaLCDbh/XomkB+19f5jmNxG+RzNdRO7QUhm7nfH81UPIt2C/MyWAlHCYkbv2wznSEb73wpxbp9tytokTgQ==}
+    engines: {node: '>=22'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -356,13 +317,6 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
-
-  tough-cookie@4.1.4:
-    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
-    engines: {node: '>=6'}
-
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   ts-mixer@6.0.4:
     resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
@@ -378,25 +332,9 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
-  universalify@0.2.0:
-    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
-    engines: {node: '>= 4.0.0'}
-
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
-
-  url-parse@1.5.10:
-    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-fetch@3.6.20:
-    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -505,18 +443,6 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
-  '@ethersproject/bignumber@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      bn.js: 5.2.2
-
-  '@ethersproject/bytes@5.8.0':
-    dependencies:
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/logger@5.8.0': {}
-
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
@@ -537,6 +463,8 @@ snapshots:
       '@noble/hashes': 1.6.0
 
   '@starknet-io/types-js@0.7.10': {}
+
+  '@starknet-io/types-js@0.8.4': {}
 
   '@types/node@22.7.5':
     dependencies:
@@ -559,8 +487,6 @@ snapshots:
 
   ansicolors@0.3.2: {}
 
-  bn.js@5.2.2: {}
-
   cardinal@2.1.1:
     dependencies:
       ansicolors: 0.3.2
@@ -578,7 +504,7 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  dotenv@16.5.0: {}
+  dotenv@16.6.1: {}
 
   emoji-regex@8.0.0: {}
 
@@ -614,7 +540,7 @@ snapshots:
 
   esprima@4.0.1: {}
 
-  ethers@6.14.4:
+  ethers@6.16.0:
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
       '@noble/curves': 1.2.0
@@ -627,32 +553,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  fetch-cookie@3.0.1:
+  fibrous-router-sdk@1.0.1:
     dependencies:
-      set-cookie-parser: 2.7.1
-      tough-cookie: 4.1.4
-
-  fibrous-router-sdk@0.4.5:
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      dotenv: 16.5.0
-      ethers: 6.14.4
-      starknet: 6.24.1
+      dotenv: 16.6.1
+      ethers: 6.16.0
+      starknet: 7.6.4
     transitivePeerDependencies:
       - bufferutil
-      - encoding
-      - utf-8-validate
-
-  fibrous-router-sdk@0.5.1:
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      dotenv: 16.5.0
-      ethers: 6.14.4
-      fibrous-router-sdk: 0.4.5
-      starknet: 6.24.1
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
       - utf-8-validate
 
   fs-extra@10.1.0:
@@ -674,13 +581,6 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  isomorphic-fetch@3.0.0:
-    dependencies:
-      node-fetch: 2.7.0
-      whatwg-fetch: 3.6.20
-    transitivePeerDependencies:
-      - encoding
-
   jsonfile@6.1.0:
     dependencies:
       universalify: 2.0.1
@@ -689,19 +589,7 @@ snapshots:
 
   lossless-json@4.1.0: {}
 
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   pako@2.1.0: {}
-
-  psl@1.15.0:
-    dependencies:
-      punycode: 2.3.1
-
-  punycode@2.3.1: {}
-
-  querystringify@2.2.0: {}
 
   redeyed@2.1.1:
     dependencies:
@@ -709,27 +597,20 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  requires-port@1.0.0: {}
-
   resolve-pkg-maps@1.0.0: {}
 
-  set-cookie-parser@2.7.1: {}
-
-  starknet@6.24.1:
+  starknet@7.6.4:
     dependencies:
       '@noble/curves': 1.7.0
       '@noble/hashes': 1.6.0
       '@scure/base': 1.2.1
       '@scure/starknet': 1.1.0
+      '@starknet-io/starknet-types-07': '@starknet-io/types-js@0.7.10'
+      '@starknet-io/starknet-types-08': '@starknet-io/types-js@0.8.4'
       abi-wan-kanabi: 2.2.4
-      fetch-cookie: 3.0.1
-      isomorphic-fetch: 3.0.0
       lossless-json: 4.1.0
       pako: 2.1.0
-      starknet-types-07: '@starknet-io/types-js@0.7.10'
       ts-mixer: 6.0.4
-    transitivePeerDependencies:
-      - encoding
 
   string-width@4.2.3:
     dependencies:
@@ -740,15 +621,6 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
-
-  tough-cookie@4.1.4:
-    dependencies:
-      psl: 1.15.0
-      punycode: 2.3.1
-      universalify: 0.2.0
-      url-parse: 1.5.10
-
-  tr46@0.0.3: {}
 
   ts-mixer@6.0.4: {}
 
@@ -763,23 +635,7 @@ snapshots:
 
   undici-types@6.19.8: {}
 
-  universalify@0.2.0: {}
-
   universalify@2.0.1: {}
-
-  url-parse@1.5.10:
-    dependencies:
-      querystringify: 2.2.0
-      requires-port: 1.0.0
-
-  webidl-conversions@3.0.1: {}
-
-  whatwg-fetch@3.6.20: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,45 +1,25 @@
 {
-  "extends": "../tsconfig.json",
   "compilerOptions": {
-    /* Examples specific - no emit and maximum flexibility */
-    "noEmit": true,
-    "declaration": false,
-    "declarationMap": false,
-    "sourceMap": false,
-
-    /* Ultra relaxed for examples and learning */
-    "strict": false,
-    "noImplicitAny": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitReturns": false,
-    "allowUnusedLabels": true,
-    "allowUnreachableCode": true,
-
-    /* Allow any imports and patterns */
-    "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true,
+    "target": "ES2020",
+    "lib": [
+      "ES2020",
+      "es7",
+      "es6",
+      "dom"
+    ],
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "downlevelIteration": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": false,
-    "resolveJsonModule": true,
-    "allowJs": true,
-    "checkJs": false,
-
-    /* Environment - include everything needed */
-    "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
-    
-    /* Skip all checks for maximum speed */
-    "skipLibCheck": true,
-    "skipDefaultLibCheck": true
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
   },
   "include": [
-    "src/**/*",
-    "**/*.ts",
-    "**/*.js"
+    "src/**/*"
   ],
   "exclude": [
-    "node_modules",
-    "**/dist",
-    "**/coverage"
+    "node_modules"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "fibrous-router-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Javascript SDK for Fibrous Finance",
-  "type": "module",
-  "main": "dist/index.cjs",
+  "main": "dist/index.js",
   "module": "dist/index.m.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -13,7 +12,7 @@
     },
     "require": {
       "types": "./dist/index.d.ts",
-      "default": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "default": "./dist/index.m.js"
   },
@@ -30,7 +29,9 @@
     "build": "rimraf dist && microbundle --tsconfig tsconfig.json",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "version:beta": "pnpm version prerelease --preid beta",
+    "publish:beta": "pnpm build && pnpm publish --tag beta --no-git-checks"
   },
   "keywords": [],
   "author": "kermo kermo@fibrous.com",
@@ -57,5 +58,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd"
 }

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -894,4 +894,15 @@ export class Router implements IRouter {
         await approveTx.wait();
         return true;
     }
+
+    /**
+     * Gets the router address for a given chain
+     * @param chainNameOrId Chain name (e.g. "starknet") or chain ID
+     * @returns Router address for the chain
+     */
+    async getRouterAddress(chainNameOrId: string | number): Promise<string> {
+        await this.ensureChainsLoaded();
+        const chain = this.getChain(chainNameOrId);
+        return chain.router_address;
+    }
 }

--- a/src/types/IROUTER.ts
+++ b/src/types/IROUTER.ts
@@ -172,4 +172,12 @@ export interface IRouter {
      * @throws ChainNotSupportedError if chain is not supported or is Starknet.
      */
     getContractWAccount(account: Wallet, chainId: number | string): Promise<Contract>;
+
+    /**
+     * Gets the router address for a given chain.
+     * @param chainNameOrId Chain name (e.g. "starknet", "scroll") or chain ID.
+     * @returns Router address for the chain.
+     * @throws ChainNotSupportedError if chain is not supported.
+     */
+    getRouterAddress(chainNameOrId: string | number): Promise<string>;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,65 +1,25 @@
 {
   "compilerOptions": {
-    /* Language and Environment */
-    "target": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "allowJs": true,
-    "checkJs": false,
-
-    /* Type Checking - Completely Flexible */
-    "strict": false,
-    "noImplicitAny": false,
-    "strictNullChecks": false,
-    "strictFunctionTypes": false,
-    "strictBindCallApply": false,
-    "strictPropertyInitialization": false,
-    "noImplicitThis": false,
-    "noImplicitReturns": false,
-    "noFallthroughCasesInSwitch": false,
-    "noUncheckedIndexedAccess": false,
-    "allowUnusedLabels": true,
-    "allowUnreachableCode": true,
-    "exactOptionalPropertyTypes": false,
-    "noImplicitOverride": false,
-    "noPropertyAccessFromIndexSignature": false,
-
-    /* Additional Flexibility */
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-
-    /* Emit */
+    "target": "ES2020",
+    "lib": [
+      "ES2020",
+      "es7",
+      "es6",
+      "dom"
+    ],
+    "module": "commonjs",
     "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
     "outDir": "dist",
-    "removeComments": false,
-    "noEmitOnError": false,
-    "noEmit": false,
-    "preserveConstEnums": true,
-
-    /* Interop Constraints */
-    "allowSyntheticDefaultImports": true,
+    "downlevelIteration": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": false,
-    "allowImportingTsExtensions": false,
-
-    /* Completeness */
-    "skipLibCheck": true,
-    "skipDefaultLibCheck": true
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "exclude": [
-    "node_modules",
-    "dist",
-    "examples",
-    "tests",
-    "**/*.test.ts",
-    "**/*.spec.ts",
-    "**/coverage",
-    "**/.DS_Store"
+    "node_modules"
   ]
 }


### PR DESCRIPTION
- Updated package.json to version 1.0.1, changing the main entry point to dist/index.js.
- Revised README files to reflect the new version.
- Enhanced tsconfig.json for stricter type checking and improved module resolution.
- Added new scripts for beta versioning and publishing in package.json.
- Updated examples to use the new SDK version and adjusted their configurations accordingly.
- Introduced a new method in the router for retrieving the router address by chain name or ID.